### PR TITLE
dependency get problem

### DIFF
--- a/apps/baz/README.md
+++ b/apps/baz/README.md
@@ -1,0 +1,20 @@
+# Baz
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+
+  1. Add baz to your list of dependencies in `mix.exs`:
+
+        def deps do
+          [{:baz, "~> 0.0.1"}]
+        end
+
+  2. Ensure baz is started before your application:
+
+        def application do
+          [applications: [:baz]]
+        end
+

--- a/apps/baz/config/config.exs
+++ b/apps/baz/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :baz, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:baz, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/apps/baz/lib/baz.ex
+++ b/apps/baz/lib/baz.ex
@@ -1,0 +1,2 @@
+defmodule Baz do
+end

--- a/apps/baz/mix.exs
+++ b/apps/baz/mix.exs
@@ -1,0 +1,37 @@
+defmodule Baz.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :baz,
+     version: "0.0.1",
+     elixir: "~> 1.2",
+     build_path: "../../_build",
+     config_path: "../../config/config.exs",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    [
+      {:foo, in_umbrella: true},
+      {:bar, in_umbrella: true, only: :test},
+    ]
+  end
+end

--- a/apps/baz/test/baz_test.exs
+++ b/apps/baz/test/baz_test.exs
@@ -1,0 +1,8 @@
+defmodule BazTest do
+  use ExUnit.Case
+  doctest Baz
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/apps/baz/test/test_helper.exs
+++ b/apps/baz/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
```
$ cd apps/baz
$ mix deps.get
Dependencies have diverged:
* bar (../bar)
the dependency bar

> In mix.exs:
    {:bar, nil, [path: "../bar", in_umbrella: true, only: :test,
manager: :mix]}

does not match the environments calculated for

> In /home/vadim/moz/ex/v-umbrella_sample/apps/foo/mix.exs:
    {:bar, nil, [path: "../bar", in_umbrella: true]}

Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```