### PR TITLE
Demonstrate issue with `in_umbrella` dependencies from another umbrella.

### DIFF
--- a/another_umbrella/.gitignore
+++ b/another_umbrella/.gitignore
@@ -1,0 +1,5 @@
+/_build
+/cover
+/deps
+erl_crash.dump
+*.ez

--- a/another_umbrella/README.md
+++ b/another_umbrella/README.md
@@ -1,0 +1,4 @@
+# AnotherUmbrella
+
+**TODO: Add description**
+

--- a/another_umbrella/apps/baz/.gitignore
+++ b/another_umbrella/apps/baz/.gitignore
@@ -1,0 +1,5 @@
+/_build
+/cover
+/deps
+erl_crash.dump
+*.ez

--- a/another_umbrella/apps/baz/README.md
+++ b/another_umbrella/apps/baz/README.md
@@ -1,0 +1,20 @@
+# Baz
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+
+  1. Add baz to your list of dependencies in `mix.exs`:
+
+        def deps do
+          [{:baz, "~> 0.0.1"}]
+        end
+
+  2. Ensure baz is started before your application:
+
+        def application do
+          [applications: [:baz]]
+        end
+

--- a/another_umbrella/apps/baz/config/config.exs
+++ b/another_umbrella/apps/baz/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :baz, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:baz, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/another_umbrella/apps/baz/lib/baz.ex
+++ b/another_umbrella/apps/baz/lib/baz.ex
@@ -1,0 +1,2 @@
+defmodule Baz do
+end

--- a/another_umbrella/apps/baz/mix.exs
+++ b/another_umbrella/apps/baz/mix.exs
@@ -1,0 +1,24 @@
+defmodule Baz.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :baz,
+     version: "0.0.1",
+     build_path: "../../_build",
+     config_path: "../../config/config.exs",
+     deps_path: "../../deps",
+     lockfile: "../../mix.lock",
+     elixir: "~> 1.2",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    [{:quux, in_umbrella: true}]
+  end
+end

--- a/another_umbrella/apps/baz/test/baz_test.exs
+++ b/another_umbrella/apps/baz/test/baz_test.exs
@@ -1,0 +1,8 @@
+defmodule BazTest do
+  use ExUnit.Case
+  doctest Baz
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/another_umbrella/apps/baz/test/test_helper.exs
+++ b/another_umbrella/apps/baz/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/another_umbrella/apps/quux/.gitignore
+++ b/another_umbrella/apps/quux/.gitignore
@@ -1,0 +1,5 @@
+/_build
+/cover
+/deps
+erl_crash.dump
+*.ez

--- a/another_umbrella/apps/quux/README.md
+++ b/another_umbrella/apps/quux/README.md
@@ -1,0 +1,20 @@
+# Quux
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+
+  1. Add quux to your list of dependencies in `mix.exs`:
+
+        def deps do
+          [{:quux, "~> 0.0.1"}]
+        end
+
+  2. Ensure quux is started before your application:
+
+        def application do
+          [applications: [:quux]]
+        end
+

--- a/another_umbrella/apps/quux/config/config.exs
+++ b/another_umbrella/apps/quux/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :quux, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:quux, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/another_umbrella/apps/quux/lib/quux.ex
+++ b/another_umbrella/apps/quux/lib/quux.ex
@@ -1,0 +1,2 @@
+defmodule Quux do
+end

--- a/another_umbrella/apps/quux/mix.exs
+++ b/another_umbrella/apps/quux/mix.exs
@@ -1,14 +1,14 @@
-defmodule Foo.Mixfile do
+defmodule Quux.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :foo,
+    [app: :quux,
      version: "0.0.1",
      build_path: "../../_build",
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.2-dev",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]
@@ -35,19 +35,6 @@ defmodule Foo.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [
-      {:bar, in_umbrella: true},
-      {:baz, path: Path.expand("../../another_umbrella/apps/baz", __DIR__)},
-    ] ++ optional_quux_dependency
-  end
-
-  if System.get_env("DEPEND_ON_QUUX") do
-    defp optional_quux_dependency do
-      [{:quux, path: Path.expand("../../another_umbrella/apps/quux", __DIR__)}]
-    end
-  else
-    defp optional_quux_dependency do
-      []
-    end
+    []
   end
 end

--- a/another_umbrella/apps/quux/test/quux_test.exs
+++ b/another_umbrella/apps/quux/test/quux_test.exs
@@ -1,0 +1,8 @@
+defmodule QuuxTest do
+  use ExUnit.Case
+  doctest Quux
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/another_umbrella/apps/quux/test/test_helper.exs
+++ b/another_umbrella/apps/quux/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/another_umbrella/config/config.exs
+++ b/another_umbrella/config/config.exs
@@ -1,0 +1,17 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# By default, the umbrella project as well as each child
+# application will require this configuration file, ensuring
+# they all use the same configuration. While one could
+# configure all applications here, we prefer to delegate
+# back to each application for organization purposes.
+import_config "../apps/*/config/config.exs"
+
+# Sample configuration (overrides the imported configuration above):
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]

--- a/another_umbrella/mix.exs
+++ b/another_umbrella/mix.exs
@@ -1,0 +1,26 @@
+defmodule AnotherUmbrella.Mixfile do
+  use Mix.Project
+
+  def project do
+    [apps_path: "apps",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options.
+  #
+  # Dependencies listed here are available only for this project
+  # and cannot be accessed from applications inside the apps folder
+  defp deps do
+    []
+  end
+end


### PR DESCRIPTION
To demo:

```
$ DEPEND_ON_QUUX=1 mix deps.get
Dependencies have diverged:
* quux (/Users/myron/code/umbrella_sample/another_umbrella/apps/quux)
  the dependency quux in apps/foo/mix.exs is overriding a child dependency:

  > In apps/foo/mix.exs:
    {:quux, nil, [path: "/Users/myron/code/umbrella_sample/another_umbrella/apps/quux", manager: :mix]}

  > In another_umbrella/apps/baz/mix.exs:
    {:quux, nil, [path: "../quux", in_umbrella: true]}

  Ensure they match or specify one of the above in your deps and set "override: true"
** (Mix) Can't continue due to errors on dependencies
```

If you do not pass `DEPEND_ON_QUUX=1`, no error results from `mix deps.get`.